### PR TITLE
Initialize monorepo structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 
 This repository contains the source code for an open‑source screenwriting application inspired by **Final Draft 13**.  It provides professional screenplay formatting, planning tools such as a beat board and outline editor, real‑time collaboration and AI‑assisted writing features.
 
+## Monorepo Structure
+
+This project is organized as a monorepo with three main packages:
+
+- **client** – React front‑end that renders the UI.
+- **server** – Node.js/Express server for collaboration APIs.
+- **ai_service** – Python FastAPI microservice that powers AI features.
+
+Each package contains its own `README` with more details.
+
 ## Features
 
 - **Automatic screenplay formatting** – Scene headings, character names and dialogue are recognized and formatted automatically, using an intuitive plain‑text syntax.

--- a/ai_service/README.md
+++ b/ai_service/README.md
@@ -1,0 +1,5 @@
+# AI Service
+
+This directory contains the Python-based AI microservice built with FastAPI.
+
+The placeholder app defines a `/status` endpoint returning a simple health check JSON.

--- a/ai_service/app.py
+++ b/ai_service/app.py
@@ -1,0 +1,7 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get("/status")
+def read_status():
+    return {"status": "ok"}

--- a/ai_service/requirements.txt
+++ b/ai_service/requirements.txt
@@ -1,0 +1,2 @@
+fastapi==0.111.0
+uvicorn==0.23.2

--- a/client/README.md
+++ b/client/README.md
@@ -1,0 +1,6 @@
+# Client
+
+This directory contains the React-based front-end for the AI-Integrated Screenwriting Tool.
+It provides the user interface and interacts with the collaboration server and AI service.
+
+The placeholder `App` component renders a simple greeting.

--- a/client/package.json
+++ b/client/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "screenwriting-client",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "start": "echo 'Run React app'"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "@types/react": "^18.0.0",
+    "@types/react-dom": "^18.0.0"
+  }
+}

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+export const App: React.FC = () => {
+  return <div>Hello, Screenwriting!</div>;
+};
+
+export default App;

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
+root.render(<App />);

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES6",
+    "module": "ESNext",
+    "jsx": "react",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "node"
+  },
+  "include": ["src"]
+}

--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,5 @@
+# Server
+
+This directory contains the Node.js/Express collaboration server for the AI-Integrated Screenwriting Tool.
+
+The placeholder server exposes a `/status` route that returns a simple health check JSON.

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "screenwriting-server",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "start": "node dist/server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0",
+    "@types/express": "^4.17.15",
+    "ts-node": "^10.0.0"
+  }
+}

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1,0 +1,12 @@
+import express from 'express';
+
+const app = express();
+const port = process.env.PORT || 3000;
+
+app.get('/status', (_req, res) => {
+  res.json({ status: 'ok' });
+});
+
+app.listen(port, () => {
+  console.log(`Server is running on port ${port}`);
+});

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES6",
+    "module": "commonjs",
+    "rootDir": "src",
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- initialize client React package with placeholder App
- add Node/Express server package with health check route
- add Python FastAPI service with status endpoint
- document each package and update root README with monorepo details

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687a91bbaf5c83248ca5cad0114bfe03