### PR TITLE
Add CodeMirror editor

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -1,6 +1,24 @@
 # Client
 
-This directory contains the React-based front-end for the AI-Integrated Screenwriting Tool.
+This directory contains the React based front-end for the AI‑Integrated Screenwriting Tool.
 It provides the user interface and interacts with the collaboration server and AI service.
 
-The placeholder `App` component renders a simple greeting.
+## Development
+
+Install dependencies and start the development server:
+
+```bash
+cd client
+npm install
+npm start
+```
+
+The app will launch a development build of the React UI. The main view now renders the **Editor** component which uses CodeMirror for screenplay editing.
+
+### Editor Usage
+
+- **Dark mode** – toggle using the toolbar button.
+- **Typewriter mode** – centers the active line vertically.
+- **Auto‑completion** – as you type character names or scene headings, suggestions appear.
+
+Future versions will expand formatting and collaboration features.

--- a/client/package.json
+++ b/client/package.json
@@ -7,7 +7,11 @@
   },
   "dependencies": {
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "@codemirror/state": "^6.2.0",
+    "@codemirror/view": "^6.6.0",
+    "@codemirror/basic-setup": "^0.19.1",
+    "@codemirror/autocomplete": "^6.4.0"
   },
   "devDependencies": {
     "typescript": "^5.0.0",

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import Editor from './components/Editor';
 
 export const App: React.FC = () => {
-  return <div>Hello, Screenwriting!</div>;
+  return <Editor />;
 };
 
 export default App;

--- a/client/src/components/Editor.css
+++ b/client/src/components/Editor.css
@@ -1,0 +1,35 @@
+.editor-wrapper {
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.toolbar {
+  padding: 4px;
+  background: #e0e0e0;
+  display: flex;
+  gap: 8px;
+}
+
+.editor-wrapper.dark .toolbar {
+  background: #333;
+}
+
+.editor {
+  flex: 1;
+}
+
+.cm-line.scene-heading {
+  font-weight: bold;
+  text-transform: uppercase;
+}
+
+.cm-line.character-name {
+  margin-left: 4em;
+  text-transform: uppercase;
+}
+
+.editor-wrapper.dark .editor {
+  background: #1e1e1e;
+  color: #f7f7f7;
+}

--- a/client/src/components/Editor.tsx
+++ b/client/src/components/Editor.tsx
@@ -1,0 +1,135 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { EditorState, Compartment, Extension } from '@codemirror/state';
+import { EditorView, keymap, Decoration, ViewUpdate } from '@codemirror/view';
+import { defaultKeymap } from '@codemirror/commands';
+import { autocompletion, CompletionContext } from '@codemirror/autocomplete';
+import { basicSetup } from '@codemirror/basic-setup';
+import './Editor.css';
+
+interface EditorProps {
+  initialText?: string;
+}
+
+const themeCompartment = new Compartment();
+const typewriterCompartment = new Compartment();
+
+const darkTheme = EditorView.theme(
+  {
+    '&': { backgroundColor: '#1e1e1e', color: '#f7f7f7', height: '100%' },
+    '.cm-content': { caretColor: '#ffffff' },
+  },
+  { dark: true },
+);
+
+const lightTheme = EditorView.theme({
+  '&': { backgroundColor: '#ffffff', color: '#000000', height: '100%' },
+});
+
+const typewriterTheme = EditorView.theme({
+  '.cm-content': {
+    maxWidth: '700px',
+    margin: '0 auto',
+    paddingTop: '40vh',
+    paddingBottom: '40vh',
+  },
+});
+
+function scriptFormatting(
+  characters: Set<string>,
+  locations: Set<string>,
+): Extension {
+  return EditorView.decorations.compute([EditorState.doc], (state) => {
+    const widgets: any[] = [];
+    for (let pos = 0; pos < state.doc.length; ) {
+      const line = state.doc.lineAt(pos);
+      const text = line.text.trim();
+      if (/^(INT|EXT)/i.test(text)) {
+        widgets.push(Decoration.line({ class: 'scene-heading' }).range(line.from));
+        const loc = text.replace(/^(INT|EXT)\.*/i, '').trim();
+        if (loc) locations.add(loc.toUpperCase());
+      } else if (/^[A-Z0-9 ]{2,30}$/.test(text) && text === text.toUpperCase()) {
+        widgets.push(Decoration.line({ class: 'character-name' }).range(line.from));
+        characters.add(text);
+      }
+      pos = line.to + 1;
+    }
+    return Decoration.set(widgets);
+  });
+}
+
+function scriptCompletion(characters: Set<string>, locations: Set<string>): Extension {
+  return autocompletion({
+    override: [
+      (ctx: CompletionContext) => {
+        const token = ctx.matchBefore(/\w+/);
+        if (!token || (token.from == token.to && !ctx.explicit)) return null;
+        const word = token.text.toUpperCase();
+        const options: { label: string }[] = [];
+        characters.forEach((name) => {
+          if (name.startsWith(word)) options.push({ label: name });
+        });
+        locations.forEach((loc) => {
+          if (loc.startsWith(word)) options.push({ label: loc });
+        });
+        if (options.length === 0) return null;
+        return {
+          from: token.from,
+          options,
+        };
+      },
+    ],
+  });
+}
+
+export const Editor: React.FC<EditorProps> = ({ initialText = '' }) => {
+  const editorRef = useRef<HTMLDivElement>(null);
+  const viewRef = useRef<EditorView>();
+  const [dark, setDark] = useState(false);
+  const [typewriter, setTypewriter] = useState(false);
+
+  const characters = useRef<Set<string>>(new Set());
+  const locations = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    if (!editorRef.current) return;
+    const startState = EditorState.create({
+      doc: initialText,
+      extensions: [
+        basicSetup,
+        keymap.of(defaultKeymap),
+        scriptFormatting(characters.current, locations.current),
+        scriptCompletion(characters.current, locations.current),
+        themeCompartment.of(lightTheme),
+        typewriterCompartment.of([]),
+      ],
+    });
+    const view = new EditorView({ state: startState, parent: editorRef.current });
+    viewRef.current = view;
+    return () => view.destroy();
+  }, [initialText]);
+
+  useEffect(() => {
+    const view = viewRef.current;
+    if (!view) return;
+    view.dispatch({ effects: themeCompartment.reconfigure(dark ? darkTheme : lightTheme) });
+  }, [dark]);
+
+  useEffect(() => {
+    const view = viewRef.current;
+    if (!view) return;
+    view.dispatch({ effects: typewriterCompartment.reconfigure(typewriter ? typewriterTheme : []) });
+  }, [typewriter]);
+
+  return (
+    <div className="editor-wrapper">
+      <div className="toolbar">
+        <button onClick={() => setDark((d) => !d)}>{dark ? 'Light' : 'Dark'} Mode</button>
+        <button onClick={() => setTypewriter((t) => !t)}>{typewriter ? 'Normal' : 'Typewriter'}</button>
+        <button disabled>Notes</button>
+      </div>
+      <div ref={editorRef} className="editor" />
+    </div>
+  );
+};
+
+export default Editor;


### PR DESCRIPTION
## Summary
- add screenplay `Editor` component based on CodeMirror
- wire the editor into `App`
- document running the client and using the editor
- include CodeMirror packages

## Testing
- `npm run lint` *(fails: Could not read package.json)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687a9476a7e88324a9ab1d8bedd1c1cd