### PR TITLE
Add drag‑and‑drop Beat Board

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -13,7 +13,14 @@ npm install
 npm start
 ```
 
-The app will launch a development build of the React UI. The main view now renders the **Editor** component which uses CodeMirror for screenplay editing.
+The app will launch a development build of the React UI. The main view now renders the **Beat Board** for planning your story structure.
+
+### Beat Board Usage
+
+- **Add lanes** – click "Add Lane" to create new columns for organizing beats.
+- **Add beats** – within each lane use "Add Beat" and fill in the prompts.
+- **Drag & drop** – reorder beats within a lane or move them between lanes.
+- Beats are saved to your browser storage so refreshing will preserve them.
 
 ### Editor Usage
 

--- a/client/package.json
+++ b/client/package.json
@@ -11,11 +11,13 @@
     "@codemirror/state": "^6.2.0",
     "@codemirror/view": "^6.6.0",
     "@codemirror/basic-setup": "^0.19.1",
-    "@codemirror/autocomplete": "^6.4.0"
+    "@codemirror/autocomplete": "^6.4.0",
+    "react-beautiful-dnd": "^13.1.0"
   },
   "devDependencies": {
     "typescript": "^5.0.0",
     "@types/react": "^18.0.0",
-    "@types/react-dom": "^18.0.0"
+    "@types/react-dom": "^18.0.0",
+    "@types/react-beautiful-dnd": "^13.1.2"
   }
 }

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import Editor from './components/Editor';
+import BeatBoard from './components/BeatBoard';
 
 export const App: React.FC = () => {
-  return <Editor />;
+  return <BeatBoard />;
 };
 
 export default App;

--- a/client/src/components/BeatBoard.css
+++ b/client/src/components/BeatBoard.css
@@ -1,0 +1,22 @@
+.beat-board {
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.lanes {
+  display: flex;
+  gap: 16px;
+  padding: 8px;
+  overflow-x: auto;
+  flex: 1;
+}
+
+.lane {
+  background: #f0f0f0;
+  padding: 8px;
+  min-width: 250px;
+  flex: 0 0 250px;
+  display: flex;
+  flex-direction: column;
+}

--- a/client/src/components/BeatBoard.tsx
+++ b/client/src/components/BeatBoard.tsx
@@ -1,0 +1,166 @@
+import React, { useEffect, useState } from 'react';
+import { DragDropContext, Droppable, Draggable, DropResult } from 'react-beautiful-dnd';
+import "./BeatBoard.css";
+import BeatCard, { Beat } from './BeatCard';
+
+interface Lane {
+  id: string;
+  title: string;
+  beatIds: string[];
+}
+
+interface BoardData {
+  beats: Record<string, Beat>;
+  lanes: Lane[];
+}
+
+const getInitialData = (): BoardData => {
+  const stored = localStorage.getItem('beat-board');
+  if (stored) {
+    try {
+      return JSON.parse(stored) as BoardData;
+    } catch {
+      /* ignore */
+    }
+  }
+  const firstBeat: Beat = {
+    id: 'beat-1',
+    title: 'Example Beat',
+    description: 'Short description',
+    color: '#ffd966',
+  };
+  return {
+    beats: { 'beat-1': firstBeat },
+    lanes: [{ id: 'lane-1', title: 'Ideas', beatIds: ['beat-1'] }],
+  };
+};
+
+export const BeatBoard: React.FC = () => {
+  const [data, setData] = useState<BoardData>(getInitialData);
+
+  useEffect(() => {
+    localStorage.setItem('beat-board', JSON.stringify(data));
+  }, [data]);
+
+  const onDragEnd = (result: DropResult) => {
+    const { source, destination, draggableId } = result;
+    if (!destination) return;
+    if (
+      source.droppableId === destination.droppableId &&
+      source.index === destination.index
+    ) {
+      return;
+    }
+    setData((prev) => {
+      const newLanes = [...prev.lanes];
+      const sourceLane = newLanes.find((l) => l.id === source.droppableId)!;
+      const destLane = newLanes.find((l) => l.id === destination.droppableId)!;
+      sourceLane.beatIds.splice(source.index, 1);
+      destLane.beatIds.splice(destination.index, 0, draggableId);
+      return { ...prev, lanes: newLanes };
+    });
+  };
+
+  const addLane = () => {
+    const title = window.prompt('Lane title');
+    if (!title) return;
+    setData((prev) => ({
+      ...prev,
+      lanes: [...prev.lanes, { id: `lane-${Date.now()}`, title, beatIds: [] }],
+    }));
+  };
+
+  const addBeat = (laneId: string) => {
+    const title = window.prompt('Beat title');
+    if (!title) return;
+    const description = window.prompt('Description') || '';
+    const color = window.prompt('Color (CSS value)', '#ffd966') || '#ffd966';
+    const id = `beat-${Date.now()}`;
+    const beat: Beat = { id, title, description, color };
+    setData((prev) => {
+      const newLanes = prev.lanes.map((l) =>
+        l.id === laneId ? { ...l, beatIds: [...l.beatIds, id] } : l,
+      );
+      return {
+        beats: { ...prev.beats, [id]: beat },
+        lanes: newLanes,
+      };
+    });
+  };
+
+  const editBeat = (id: string) => {
+    const beat = data.beats[id];
+    const title = window.prompt('Beat title', beat.title);
+    if (!title) return;
+    const description = window.prompt('Description', beat.description) || '';
+    const color = window.prompt('Color', beat.color) || beat.color;
+    setData((prev) => ({
+      ...prev,
+      beats: { ...prev.beats, [id]: { ...beat, title, description, color } },
+    }));
+  };
+
+  const deleteBeat = (id: string, laneId: string) => {
+    if (!window.confirm('Delete beat?')) return;
+    setData((prev) => {
+      const newBeats = { ...prev.beats };
+      delete newBeats[id];
+      const newLanes = prev.lanes.map((l) =>
+        l.id === laneId ? { ...l, beatIds: l.beatIds.filter((b) => b !== id) } : l,
+      );
+      return { beats: newBeats, lanes: newLanes };
+    });
+  };
+
+  return (
+    <div className="beat-board">
+      <div style={{ padding: '8px' }}>
+        <button onClick={addLane}>Add Lane</button>
+      </div>
+      <DragDropContext onDragEnd={onDragEnd}>
+        <div className="lanes">
+          {data.lanes.map((lane) => (
+            <Droppable droppableId={lane.id} key={lane.id}>
+              {(provided) => (
+                <div
+                  ref={provided.innerRef}
+                  {...provided.droppableProps}
+                  className="lane"
+                >
+                  <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                    <h3>{lane.title}</h3>
+                    <button onClick={() => addBeat(lane.id)}>Add Beat</button>
+                  </div>
+                  {lane.beatIds.map((beatId, index) => {
+                    const beat = data.beats[beatId];
+                    if (!beat) return null;
+                    return (
+                      <Draggable draggableId={beat.id} index={index} key={beat.id}>
+                        {(prov) => (
+                          <div
+                            ref={prov.innerRef}
+                            {...prov.draggableProps}
+                            {...prov.dragHandleProps}
+                          >
+                            <BeatCard
+                              beat={beat}
+                              onEdit={() => editBeat(beat.id)}
+                              onDelete={() => deleteBeat(beat.id, lane.id)}
+                            />
+                          </div>
+                        )}
+                      </Draggable>
+                    );
+                  })
+                  {provided.placeholder}
+                </div>
+              )}
+            </Droppable>
+          ))}
+        </div>
+      </DragDropContext>
+    </div>
+  );
+};
+
+export default BeatBoard;

--- a/client/src/components/BeatCard.tsx
+++ b/client/src/components/BeatCard.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+
+export interface Beat {
+  id: string;
+  title: string;
+  description: string;
+  color: string;
+  connections?: string[]; // placeholder for flow lines
+}
+
+interface BeatCardProps {
+  beat: Beat;
+  onEdit: () => void;
+  onDelete: () => void;
+}
+
+const cardStyle: React.CSSProperties = {
+  padding: '8px',
+  borderRadius: '4px',
+  marginBottom: '8px',
+  color: '#000',
+};
+
+export const BeatCard: React.FC<BeatCardProps> = ({ beat, onEdit, onDelete }) => {
+  return (
+    <div style={{ ...cardStyle, background: beat.color }}>
+      <strong>{beat.title}</strong>
+      <p>{beat.description}</p>
+      <div>
+        <button onClick={onEdit}>Edit</button>
+        <button onClick={onDelete}>Delete</button>
+      </div>
+    </div>
+  );
+};
+
+export default BeatCard;


### PR DESCRIPTION
## Summary
- implement BeatBoard and BeatCard components
- switch app entry to BeatBoard
- document Beat Board usage and update client readme
- add react-beautiful-dnd dependency

## Testing
- `npm run lint` *(fails: Missing script)*
- `npm run format` *(fails: Missing script)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687a98b48c90832488dc2da3678b28c7