### PR TITLE
Add drag-and-drop Outline Editor

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -13,7 +13,7 @@ npm install
 npm start
 ```
 
-The app will launch a development build of the React UI. The main view now renders the **Beat Board** for planning your story structure.
+The app will launch a development build of the React UI. A simple toolbar allows switching between the **Beat Board**, **Outline Editor** and script **Editor** views.
 
 ### Beat Board Usage
 
@@ -22,10 +22,23 @@ The app will launch a development build of the React UI. The main view now rende
 - **Drag & drop** – reorder beats within a lane or move them between lanes.
 - Beats are saved to your browser storage so refreshing will preserve them.
 
+### Outline Editor Usage
+
+- Click "Outline Editor" in the toolbar to open it.
+- **Add lanes** – create structural lanes (e.g., Acts or Sequences).
+- **Add cards** – each card can be given a title, description and color.
+- **Drag & drop** – move cards within and between lanes to plan your story.
+- Edit lane titles or delete lanes using the lane controls.
+- The outline persists to `localStorage` under the key `outlineData`.
+
 ### Editor Usage
 
 - **Dark mode** – toggle using the toolbar button.
 - **Typewriter mode** – centers the active line vertically.
 - **Auto‑completion** – as you type character names or scene headings, suggestions appear.
+
+### Dependencies
+
+The front-end relies on `react-beautiful-dnd` for drag and drop interactions, along with `@codemirror` packages for the screenplay editor.
 
 Future versions will expand formatting and collaboration features.

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,8 +1,23 @@
-import React from 'react';
+import React, { useState } from 'react';
 import BeatBoard from './components/BeatBoard';
+import Editor from './components/Editor';
+import OutlineEditor from './components/OutlineEditor';
 
 export const App: React.FC = () => {
-  return <BeatBoard />;
+  const [view, setView] = useState<'board' | 'outline' | 'editor'>('board');
+
+  return (
+    <div>
+      <div style={{ padding: '8px', background: '#e0e0e0', display: 'flex', gap: '8px' }}>
+        <button onClick={() => setView('board')}>Beat Board</button>
+        <button onClick={() => setView('outline')}>Outline Editor</button>
+        <button onClick={() => setView('editor')}>Editor</button>
+      </div>
+      {view === 'board' && <BeatBoard />}
+      {view === 'outline' && <OutlineEditor />}
+      {view === 'editor' && <Editor />}
+    </div>
+  );
 };
 
 export default App;

--- a/client/src/components/OutlineEditor.css
+++ b/client/src/components/OutlineEditor.css
@@ -1,0 +1,50 @@
+.outline-editor {
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.outline-toolbar {
+  padding: 8px;
+  background: #e0e0e0;
+}
+
+.outline-lanes {
+  display: flex;
+  gap: 16px;
+  padding: 8px;
+  overflow-x: auto;
+  flex: 1;
+}
+
+.outline-lane {
+  background: #f8f8f8;
+  padding: 8px;
+  min-width: 250px;
+  flex: 0 0 250px;
+  display: flex;
+  flex-direction: column;
+  position: relative;
+}
+
+.lane-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.outline-card {
+  padding: 8px;
+  border-radius: 4px;
+  margin-bottom: 8px;
+  color: #000;
+}
+
+.structure-line {
+  position: absolute;
+  right: -8px;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: #ccc;
+}

--- a/client/src/components/OutlineEditor.tsx
+++ b/client/src/components/OutlineEditor.tsx
@@ -1,0 +1,205 @@
+import React, { useEffect, useState } from 'react';
+import { DragDropContext, Droppable, Draggable, DropResult } from 'react-beautiful-dnd';
+import './OutlineEditor.css';
+
+interface Card {
+  id: string;
+  title: string;
+  description: string;
+  color: string;
+}
+
+interface Lane {
+  id: string;
+  title: string;
+  cardIds: string[];
+}
+
+interface OutlineData {
+  cards: Record<string, Card>;
+  lanes: Lane[];
+}
+
+const STORAGE_KEY = 'outlineData';
+
+const getInitialData = (): OutlineData => {
+  const stored = localStorage.getItem(STORAGE_KEY);
+  if (stored) {
+    try {
+      return JSON.parse(stored) as OutlineData;
+    } catch {
+      /* ignore */
+    }
+  }
+  const firstCard: Card = {
+    id: 'card-1',
+    title: 'Example Card',
+    description: 'Short description',
+    color: '#cfe2ff',
+  };
+  return {
+    cards: { 'card-1': firstCard },
+    lanes: [{ id: 'lane-1', title: 'Act I', cardIds: ['card-1'] }],
+  };
+};
+
+const OutlineCard: React.FC<{
+  card: Card;
+  onEdit: () => void;
+  onDelete: () => void;
+}> = ({ card, onEdit, onDelete }) => (
+  <div className="outline-card" style={{ background: card.color }}>
+    <strong>{card.title}</strong>
+    <p>{card.description}</p>
+    <div>
+      <button onClick={onEdit}>Edit</button>
+      <button onClick={onDelete}>Delete</button>
+    </div>
+  </div>
+);
+
+export const OutlineEditor: React.FC = () => {
+  const [data, setData] = useState<OutlineData>(getInitialData);
+
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+  }, [data]);
+
+  const onDragEnd = (result: DropResult) => {
+    const { source, destination, draggableId } = result;
+    if (!destination) return;
+    if (source.droppableId === destination.droppableId && source.index === destination.index) return;
+
+    setData((prev) => {
+      const newLanes = [...prev.lanes];
+      const sourceLane = newLanes.find((l) => l.id === source.droppableId)!;
+      const destLane = newLanes.find((l) => l.id === destination.droppableId)!;
+      sourceLane.cardIds.splice(source.index, 1);
+      destLane.cardIds.splice(destination.index, 0, draggableId);
+      return { ...prev, lanes: newLanes };
+    });
+  };
+
+  const addLane = () => {
+    const title = window.prompt('Lane title');
+    if (!title) return;
+    setData((prev) => ({
+      ...prev,
+      lanes: [...prev.lanes, { id: `lane-${Date.now()}`, title, cardIds: [] }],
+    }));
+  };
+
+  const editLane = (id: string) => {
+    const lane = data.lanes.find((l) => l.id === id);
+    if (!lane) return;
+    const title = window.prompt('Lane title', lane.title);
+    if (!title) return;
+    setData((prev) => ({
+      ...prev,
+      lanes: prev.lanes.map((l) => (l.id === id ? { ...l, title } : l)),
+    }));
+  };
+
+  const deleteLane = (id: string) => {
+    if (!window.confirm('Delete lane?')) return;
+    setData((prev) => {
+      const lane = prev.lanes.find((l) => l.id === id);
+      if (!lane) return prev;
+      const newCards = { ...prev.cards };
+      lane.cardIds.forEach((cid) => delete newCards[cid]);
+      return {
+        cards: newCards,
+        lanes: prev.lanes.filter((l) => l.id !== id),
+      };
+    });
+  };
+
+  const addCard = (laneId: string) => {
+    const title = window.prompt('Card title');
+    if (!title) return;
+    const description = window.prompt('Description') || '';
+    const color = window.prompt('Color (CSS value)', '#cfe2ff') || '#cfe2ff';
+    const id = `card-${Date.now()}`;
+    const card: Card = { id, title, description, color };
+    setData((prev) => {
+      const newLanes = prev.lanes.map((l) => (l.id === laneId ? { ...l, cardIds: [...l.cardIds, id] } : l));
+      return {
+        cards: { ...prev.cards, [id]: card },
+        lanes: newLanes,
+      };
+    });
+  };
+
+  const editCard = (id: string) => {
+    const card = data.cards[id];
+    if (!card) return;
+    const title = window.prompt('Card title', card.title);
+    if (!title) return;
+    const description = window.prompt('Description', card.description) || '';
+    const color = window.prompt('Color', card.color) || card.color;
+    setData((prev) => ({
+      ...prev,
+      cards: { ...prev.cards, [id]: { ...card, title, description, color } },
+    }));
+  };
+
+  const deleteCard = (id: string, laneId: string) => {
+    if (!window.confirm('Delete card?')) return;
+    setData((prev) => {
+      const newCards = { ...prev.cards };
+      delete newCards[id];
+      const newLanes = prev.lanes.map((l) =>
+        l.id === laneId ? { ...l, cardIds: l.cardIds.filter((cid) => cid !== id) } : l,
+      );
+      return { cards: newCards, lanes: newLanes };
+    });
+  };
+
+  return (
+    <div className="outline-editor">
+      <div className="outline-toolbar">
+        <button onClick={addLane}>Add Lane</button>
+      </div>
+      <DragDropContext onDragEnd={onDragEnd}>
+        <div className="outline-lanes">
+          {data.lanes.map((lane) => (
+            <Droppable droppableId={lane.id} key={lane.id}>
+              {(provided) => (
+                <div ref={provided.innerRef} {...provided.droppableProps} className="outline-lane">
+                  <div className="lane-header">
+                    <h3 onClick={() => editLane(lane.id)}>{lane.title}</h3>
+                    <div>
+                      <button onClick={() => addCard(lane.id)}>Add Card</button>
+                      <button onClick={() => deleteLane(lane.id)}>Delete Lane</button>
+                    </div>
+                  </div>
+                  {lane.cardIds.map((cid, index) => {
+                    const card = data.cards[cid];
+                    if (!card) return null;
+                    return (
+                      <Draggable draggableId={card.id} index={index} key={card.id}>
+                        {(prov) => (
+                          <div ref={prov.innerRef} {...prov.draggableProps} {...prov.dragHandleProps}>
+                            <OutlineCard
+                              card={card}
+                              onEdit={() => editCard(card.id)}
+                              onDelete={() => deleteCard(card.id, lane.id)}
+                            />
+                          </div>
+                        )}
+                      </Draggable>
+                    );
+                  })}
+                  {provided.placeholder}
+                  <div className="structure-line" />
+                </div>
+              )}
+            </Droppable>
+          ))}
+        </div>
+      </DragDropContext>
+    </div>
+  );
+};
+
+export default OutlineEditor;


### PR DESCRIPTION
## Summary
- create `OutlineEditor` component with drag and drop cards and lanes
- persist outline data to `localStorage`
- simple toolbar switch between Beat Board, Outline Editor and Editor
- document Outline Editor usage in client README

## Testing
- `npm run format` *(fails: Missing package.json)*
- `npm run lint` *(fails: Missing package.json)*
- `npm run format` in client *(fails: missing script)*
- `npm run lint` in client *(fails: missing script)*
- `npm run format` in server *(fails: missing script)*
- `npm run lint` in server *(fails: missing script)*
- `npm test --silent` *(no tests configured)*

------
https://chatgpt.com/codex/tasks/task_e_687a9da9608083249b6fdf133bfaac7b