### PR TITLE
Add analysis and autocomplete to AI service

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ For a full description of the planned architecture and feature roadmap, see **de
 
    # Run the AI service (optional)
    cd ai_service
-   uvicorn app:app --reload
+   uvicorn main:app --reload
    ```
 
    The app will open in a desktop window.  By default, it connects to the local API server and AI service.

--- a/ai_service/README.md
+++ b/ai_service/README.md
@@ -1,5 +1,27 @@
 # AI Service
 
 This directory contains the Python-based AI microservice built with FastAPI.
+It exposes several endpoints used by the main application. The current
+implementation uses simple placeholder logic that will later be replaced with
+real AI models.
 
-The placeholder app defines a `/status` endpoint returning a simple health check JSON.
+## Running
+
+Install the dependencies and start the service with Uvicorn:
+
+```bash
+pip install -r requirements.txt
+uvicorn main:app --reload
+```
+
+## Endpoints
+
+- `GET /status` – Health check returning `{"status": "ok"}`.
+- `POST /analyze` – Accepts a JSON body with a `script` field and optional
+  `outline`. Returns basic statistics about the script and placeholder
+  suggestions.
+- `POST /autocomplete` – Accepts `script` and `current_text`. Returns a list of
+  simple autocompletion strings.
+
+These endpoints currently perform minimal text processing and should be replaced
+with real AI logic in the future.

--- a/ai_service/app.py
+++ b/ai_service/app.py
@@ -1,7 +1,7 @@
-from fastapi import FastAPI
+"""Compatibility module for running ``uvicorn app:app``.
 
-app = FastAPI()
+This file imports the FastAPI ``app`` instance from ``main.py`` so that legacy
+commands referencing ``app:app`` continue to work.
+"""
 
-@app.get("/status")
-def read_status():
-    return {"status": "ok"}
+from .main import app  # noqa: F401  # re-export for Uvicorn

--- a/ai_service/main.py
+++ b/ai_service/main.py
@@ -1,0 +1,82 @@
+from typing import List, Optional, Union
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+app = FastAPI()
+
+
+class AnalyzeRequest(BaseModel):
+    """Request body for the /analyze endpoint."""
+
+    script: str
+    outline: Optional[Union[str, List[str]]] = None
+
+
+class AnalyzeResponse(BaseModel):
+    """Response returned by the /analyze endpoint."""
+
+    word_count: int
+    character_count: int
+    unique_words: int
+    suggestions: List[str]
+
+
+class AutocompleteRequest(BaseModel):
+    """Request body for the /autocomplete endpoint."""
+
+    script: str
+    current_text: str
+
+
+class AutocompleteResponse(BaseModel):
+    """Response returned by the /autocomplete endpoint."""
+
+    completions: List[str]
+
+
+@app.get("/status")
+def read_status():
+    """Simple health check used by the client application."""
+
+    return {"status": "ok"}
+
+
+@app.post("/analyze", response_model=AnalyzeResponse)
+def analyze_script(request: AnalyzeRequest) -> AnalyzeResponse:
+    """Return basic statistics about the provided script.
+
+    This placeholder implementation performs simple text processing and
+    returns generic suggestions. It should be replaced with real AI logic
+    in the future.
+    """
+
+    words = request.script.split()
+    cleaned_words = [w.strip(".,!?;:\"'").lower() for w in words]
+    word_count = len(words)
+    character_count = len(request.script)
+    unique_words = len(set(cleaned_words))
+    suggestions = ["Consider increasing conflict in Act II."]
+
+    return AnalyzeResponse(
+        word_count=word_count,
+        character_count=character_count,
+        unique_words=unique_words,
+        suggestions=suggestions,
+    )
+
+
+@app.post("/autocomplete", response_model=AutocompleteResponse)
+def autocomplete(request: AutocompleteRequest) -> AutocompleteResponse:
+    """Return placeholder autocompletion suggestions for the current text.
+
+    The current implementation simply reverses the last three words of the
+    provided text. This will later call an AI model for real suggestions.
+    """
+
+    words = request.current_text.split()
+    last_three = words[-3:]
+    reversed_words = " ".join(reversed(last_three))
+    suggestions = [reversed_words]
+
+    return AutocompleteResponse(completions=suggestions)

--- a/ai_service/tests/test_endpoints.py
+++ b/ai_service/tests/test_endpoints.py
@@ -1,0 +1,33 @@
+import sys, os; sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
+from fastapi.testclient import TestClient
+
+from ai_service.main import app
+
+client = TestClient(app)
+
+
+def test_status():
+    response = client.get("/status")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+def test_analyze():
+    payload = {"script": "Hello world"}
+    response = client.post("/analyze", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["word_count"] == 2
+    assert data["character_count"] == len("Hello world")
+    assert data["unique_words"] == 2
+    assert isinstance(data["suggestions"], list)
+
+
+def test_autocomplete():
+    payload = {"script": "", "current_text": "hello amazing world"}
+    response = client.post("/autocomplete", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert "completions" in data
+    assert isinstance(data["completions"], list)
+    assert len(data["completions"]) > 0


### PR DESCRIPTION
## Summary
- create `main.py` FastAPI app with `/analyze` and `/autocomplete`
- keep `app.py` for backward compatibility
- document new endpoints in `ai_service/README.md`
- update root README to run service via `uvicorn main:app`
- add basic tests for new endpoints

## Testing
- `pytest -q ai_service/tests/test_endpoints.py`

------
https://chatgpt.com/codex/tasks/task_e_687aa30f89388324976bbf43a882fae7