### PR TITLE
Implement API-based storage for beats and outlines

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -1,7 +1,7 @@
 # Client
 
 This directory contains the React based front-end for the AI‑Integrated Screenwriting Tool.
-It provides the user interface and interacts with the collaboration server and AI service.
+It provides the user interface and interacts with the collaboration server and AI service. Beat board and outline data are fetched from the server's JSON API instead of using browser storage.
 
 ## Development
 
@@ -18,9 +18,9 @@ The app will launch a development build of the React UI. A simple toolbar allows
 ### Beat Board Usage
 
 - **Add lanes** – click "Add Lane" to create new columns for organizing beats.
-- **Add beats** – within each lane use "Add Beat" and fill in the prompts.
+- **Add beats** – within each lane use "Add Beat" and fill in the inline form.
 - **Drag & drop** – reorder beats within a lane or move them between lanes.
-- Beats are saved to your browser storage so refreshing will preserve them.
+- Beat data is loaded from the development API and saved back whenever changes are made.
 
 ### Outline Editor Usage
 
@@ -29,7 +29,7 @@ The app will launch a development build of the React UI. A simple toolbar allows
 - **Add cards** – each card can be given a title, description and color.
 - **Drag & drop** – move cards within and between lanes to plan your story.
 - Edit lane titles or delete lanes using the lane controls.
-- The outline persists to `localStorage` under the key `outlineData`.
+- Outline data is loaded from the development API and persisted via API calls.
 
 ### Editor Usage
 

--- a/client/package.json
+++ b/client/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "start": "echo 'Run React app'"
+    "start": "echo 'Use a development server such as Vite to run this app'"
   },
   "dependencies": {
     "react": "^18.2.0",

--- a/server/README.md
+++ b/server/README.md
@@ -1,5 +1,17 @@
 # Server
 
-This directory contains the Node.js/Express collaboration server for the AI-Integrated Screenwriting Tool.
+This directory contains the Node.js/Express collaboration server for the AI‑Integrated Screenwriting Tool.
 
-The placeholder server exposes a `/status` route that returns a simple health check JSON.
+The development server exposes a small JSON REST API backed by an in‑memory store. It is intended only for testing purposes and does not persist data between runs.
+
+### Available Endpoints
+
+* `GET /status` – Health check.
+* `GET /projects` – List all projects.
+* `POST /projects` – Create a new project. Body: `{ "name": "My Project" }`.
+* `GET /projects/:id/beats` – Retrieve beat board data for a project.
+* `PUT /projects/:id/beats` – Replace the beat board data.
+* `GET /projects/:id/outlines` – Retrieve outline data for a project.
+* `PUT /projects/:id/outlines` – Replace the outline data.
+
+All routes accept and return JSON. CORS headers are enabled so that the React client can communicate with the API during development.

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1,10 +1,120 @@
 import express from 'express';
 
+interface Beat {
+  id: string;
+  title: string;
+  description: string;
+  color: string;
+}
+
+interface BeatLane {
+  id: string;
+  title: string;
+  beatIds: string[];
+}
+
+interface BeatsData {
+  beats: Record<string, Beat>;
+  lanes: BeatLane[];
+}
+
+interface Card {
+  id: string;
+  title: string;
+  description: string;
+  color: string;
+}
+
+interface OutlineLane {
+  id: string;
+  title: string;
+  cardIds: string[];
+}
+
+interface OutlineData {
+  cards: Record<string, Card>;
+  lanes: OutlineLane[];
+}
+
+interface Project {
+  id: number;
+  name: string;
+}
+
 const app = express();
 const port = process.env.PORT || 3000;
 
+app.use(express.json());
+
+app.use((req, res, next) => {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+  res.setHeader('Access-Control-Allow-Methods', 'GET,POST,PUT,DELETE,OPTIONS');
+  if (req.method === 'OPTIONS') {
+    return res.sendStatus(204);
+  }
+  next();
+});
+
+const projects: Project[] = [{ id: 1, name: 'Default Project' }];
+const beatsStore: Record<number, BeatsData> = {
+  1: { beats: {}, lanes: [] },
+};
+const outlineStore: Record<number, OutlineData> = {
+  1: { cards: {}, lanes: [] },
+};
+
 app.get('/status', (_req, res) => {
   res.json({ status: 'ok' });
+});
+
+app.get('/projects', (_req, res) => {
+  res.json(projects);
+});
+
+app.post('/projects', (req, res) => {
+  const { name } = req.body as { name?: string };
+  if (!name) {
+    return res.status(400).json({ error: 'name is required' });
+  }
+  const id = Date.now();
+  const project: Project = { id, name };
+  projects.push(project);
+  beatsStore[id] = { beats: {}, lanes: [] };
+  outlineStore[id] = { cards: {}, lanes: [] };
+  res.status(201).json(project);
+});
+
+app.get('/projects/:projectId/beats', (req, res) => {
+  const id = Number(req.params.projectId);
+  const data = beatsStore[id];
+  if (!data) {
+    return res.status(404).json({ error: 'project not found' });
+  }
+  res.json(data);
+});
+
+app.put('/projects/:projectId/beats', (req, res) => {
+  const id = Number(req.params.projectId);
+  const data = req.body as BeatsData;
+  beatsStore[id] = data;
+  res.json({ status: 'saved' });
+});
+
+app.get('/projects/:projectId/outlines', (req, res) => {
+  const id = Number(req.params.projectId);
+  const data = outlineStore[id];
+  if (!data) {
+    return res.status(404).json({ error: 'project not found' });
+  }
+  res.json(data);
+});
+
+app.put('/projects/:projectId/outlines', (req, res) => {
+  const id = Number(req.params.projectId);
+  const data = req.body as OutlineData;
+  outlineStore[id] = data;
+  res.json({ status: 'saved' });
 });
 
 app.listen(port, () => {


### PR DESCRIPTION
## Summary
- add REST endpoints to the dev server for projects, beats and outline data
- make client fetch beat board and outline data from the server instead of localStorage
- provide inline forms for adding lanes and items
- document the API and update usage docs
- adjust client start script placeholder

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'express')*
- `npx tsc --noEmit` in client *(fails: BeatBoard.tsx: '}' expected)*

------
https://chatgpt.com/codex/tasks/task_e_687ac97931948324996bf2588e628d5c